### PR TITLE
Handle rate limiting with a retryable http client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/louy/terraform-provider-uptimerobot
 
 go 1.12
 
-require github.com/hashicorp/terraform-plugin-sdk v1.0.0
+require (
+	github.com/hashicorp/go-retryablehttp v0.7.0
+	github.com/hashicorp/terraform-plugin-sdk v1.0.0
+)

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uP
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-plugin v1.0.1 h1:4OtAfUGbnKC6yS48p0CtMX2oFYtzFZVv6rok3cRWgnE=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
+github.com/hashicorp/go-retryablehttp v0.7.0 h1:eu1EI/mbirUgP5C8hVsTNaGZreBDlYiwC1FZWkvQPQ4=
+github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=


### PR DESCRIPTION
I was having trouble using the provider because I was being
rate limited, and the error was "null" because it wasn't in json.

This change adds the hashicorp retryable http client which will
understand the 429s and exponentially backoff.

Additionally, if there is anything else weird that happens that
results in a non-200 or bad json, the error will be more visible
to the user.