### PR TITLE
Add timeout parameter

### DIFF
--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -54,6 +54,7 @@ resource "uptimerobot_monitor" "my_website" {
   - `basic`
   - `digest`
 * `interval` - the interval for the monitoring check (300 seconds by default).
+* `timeout` - the timeout for the monitoring check (30 seconds by default). Available for HTTP, port and keyword monitoring.
 
 ## Attributes Reference
 

--- a/internal/provider/api/monitor.go
+++ b/internal/provider/api/monitor.go
@@ -71,6 +71,7 @@ type Monitor struct {
 	Type         string `json:"type"`
 	Status       string `json:"status"`
 	Interval     int    `json:"interval"`
+	Timeout      int    `json:"timeout"`
 
 	SubType string `json:"sub_type"`
 	Port    int    `json:"port"`
@@ -135,6 +136,7 @@ func (client UptimeRobotApiClient) GetMonitor(id int) (m Monitor, err error) {
 		} else {
 			m.Port = int(monitor["port"].(float64))
 		}
+		m.Timeout = int(monitor["timeout"].(float64))
 		break
 	case "keyword":
 		m.KeywordType = intToString(monitorKeywordType, int(monitor["keyword_type"].(float64)))
@@ -151,6 +153,7 @@ func (client UptimeRobotApiClient) GetMonitor(id int) (m Monitor, err error) {
 		// m.HTTPMethod = intToString(monitorHTTPMethod, int(monitor["http_method"].(float64)))
 		m.HTTPUsername = monitor["http_username"].(string)
 		m.HTTPPassword = monitor["http_password"].(string)
+		m.Timeout = int(monitor["timeout"].(float64))
 		break
 	case "http":
 		if val := monitor["http_auth_type"]; val != nil {
@@ -164,6 +167,7 @@ func (client UptimeRobotApiClient) GetMonitor(id int) (m Monitor, err error) {
 		// m.HTTPMethod = intToString(monitorHTTPMethod, int(monitor["http_method"].(float64)))
 		m.HTTPUsername = monitor["http_username"].(string)
 		m.HTTPPassword = monitor["http_password"].(string)
+		m.Timeout = int(monitor["timeout"].(float64))
 		break
 	}
 
@@ -205,6 +209,7 @@ type MonitorCreateRequest struct {
 	URL          string
 	Type         string
 	Interval     int
+	Timeout      int
 
 	SubType string
 	Port    int
@@ -234,6 +239,7 @@ func (client UptimeRobotApiClient) CreateMonitor(req MonitorCreateRequest) (m Mo
 	case "port":
 		data.Add("sub_type", fmt.Sprintf("%d", monitorSubType[req.SubType]))
 		data.Add("port", fmt.Sprintf("%d", req.Port))
+		data.Add("timeout", fmt.Sprintf("%d", req.Timeout))
 		break
 	case "keyword":
 		data.Add("keyword_type", fmt.Sprintf("%d", monitorKeywordType[req.KeywordType]))
@@ -243,6 +249,7 @@ func (client UptimeRobotApiClient) CreateMonitor(req MonitorCreateRequest) (m Mo
 		data.Add("http_auth_type", fmt.Sprintf("%d", monitorHTTPAuthType[req.HTTPAuthType]))
 		data.Add("http_username", req.HTTPUsername)
 		data.Add("http_password", req.HTTPPassword)
+		data.Add("timeout", fmt.Sprintf("%d", req.Timeout))
 		break
 	case "http":
 		data.Add("http_method", fmt.Sprintf("%d", monitorHTTPMethod[req.HTTPMethod]))
@@ -254,6 +261,7 @@ func (client UptimeRobotApiClient) CreateMonitor(req MonitorCreateRequest) (m Mo
 			data.Add("post_content_type", "0")
 			data.Add("post_value", "{}")
 		}
+		data.Add("timeout", fmt.Sprintf("%d", req.Timeout))
 		break
 	}
 
@@ -297,6 +305,7 @@ type MonitorUpdateRequest struct {
 	URL          string
 	Type         string
 	Interval     int
+	Timeout      int
 
 	SubType string
 	Port    int
@@ -327,6 +336,7 @@ func (client UptimeRobotApiClient) UpdateMonitor(req MonitorUpdateRequest) (m Mo
 	case "port":
 		data.Add("sub_type", fmt.Sprintf("%d", monitorSubType[req.SubType]))
 		data.Add("port", fmt.Sprintf("%d", req.Port))
+		data.Add("timeout", fmt.Sprintf("%d", req.Timeout))
 		break
 	case "keyword":
 		data.Add("keyword_type", fmt.Sprintf("%d", monitorKeywordType[req.KeywordType]))
@@ -336,12 +346,14 @@ func (client UptimeRobotApiClient) UpdateMonitor(req MonitorUpdateRequest) (m Mo
 		data.Add("http_auth_type", fmt.Sprintf("%d", monitorHTTPAuthType[req.HTTPAuthType]))
 		data.Add("http_username", req.HTTPUsername)
 		data.Add("http_password", req.HTTPPassword)
+		data.Add("timeout", fmt.Sprintf("%d", req.Timeout))
 		break
 	case "http":
 		data.Add("http_method", fmt.Sprintf("%d", monitorHTTPMethod[req.HTTPMethod]))
 		data.Add("http_auth_type", fmt.Sprintf("%d", monitorHTTPAuthType[req.HTTPAuthType]))
 		data.Add("http_username", req.HTTPUsername)
 		data.Add("http_password", req.HTTPPassword)
+		data.Add("timeout", fmt.Sprintf("%d", req.Timeout))
 		break
 	}
 

--- a/internal/provider/resource_uptimerobot_monitor.go
+++ b/internal/provider/resource_uptimerobot_monitor.go
@@ -61,6 +61,11 @@ func resourceMonitor() *schema.Resource {
 				Optional: true,
 				Default:  300,
 			},
+			"timeout": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  30,
+			},
 			"http_method": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -131,6 +136,7 @@ func resourceMonitorCreate(d *schema.ResourceData, m interface{}) error {
 	case "port":
 		req.SubType = d.Get("sub_type").(string)
 		req.Port = d.Get("port").(int)
+		req.Timeout = d.Get("timeout").(int)
 		break
 	case "keyword":
 		req.KeywordType = d.Get("keyword_type").(string)
@@ -140,12 +146,14 @@ func resourceMonitorCreate(d *schema.ResourceData, m interface{}) error {
 		req.HTTPUsername = d.Get("http_username").(string)
 		req.HTTPPassword = d.Get("http_password").(string)
 		req.HTTPAuthType = d.Get("http_auth_type").(string)
+		req.Timeout = d.Get("timeout").(int)
 		break
 	case "http":
 		req.HTTPMethod = d.Get("http_method").(string)
 		req.HTTPUsername = d.Get("http_username").(string)
 		req.HTTPPassword = d.Get("http_password").(string)
 		req.HTTPAuthType = d.Get("http_auth_type").(string)
+		req.Timeout = d.Get("timeout").(int)
 		break
 	}
 
@@ -216,6 +224,7 @@ func resourceMonitorUpdate(d *schema.ResourceData, m interface{}) error {
 	case "port":
 		req.SubType = d.Get("sub_type").(string)
 		req.Port = d.Get("port").(int)
+		req.Timeout = d.Get("timeout").(int)
 		break
 	case "keyword":
 		req.KeywordType = d.Get("keyword_type").(string)
@@ -225,12 +234,14 @@ func resourceMonitorUpdate(d *schema.ResourceData, m interface{}) error {
 		req.HTTPUsername = d.Get("http_username").(string)
 		req.HTTPPassword = d.Get("http_password").(string)
 		req.HTTPAuthType = d.Get("http_auth_type").(string)
+		req.Timeout = d.Get("timeout").(int)
 		break
 	case "http":
 		req.HTTPMethod = d.Get("http_method").(string)
 		req.HTTPUsername = d.Get("http_username").(string)
 		req.HTTPPassword = d.Get("http_password").(string)
 		req.HTTPAuthType = d.Get("http_auth_type").(string)
+		req.Timeout = d.Get("timeout").(int)
 		break
 	}
 
@@ -283,6 +294,7 @@ func updateMonitorResource(d *schema.ResourceData, m uptimerobotapi.Monitor) err
 	d.Set("type", m.Type)
 	d.Set("status", m.Status)
 	d.Set("interval", m.Interval)
+	d.Set("timeout", m.Timeout)
 
 	d.Set("sub_type", m.SubType)
 	d.Set("port", m.Port)

--- a/internal/provider/resource_uptimerobot_monitor_test.go
+++ b/internal/provider/resource_uptimerobot_monitor_test.go
@@ -504,6 +504,198 @@ func TestUptimeRobotDataResourceMonitor_custom_interval(t *testing.T) {
 	})
 }
 
+func TestUptimeRobotDataResourceMonitor_custom_timeout_http(t *testing.T) {
+	var FriendlyName = "TF Test: custom timeout http"
+	var Type = "http"
+	var URL = "https://google.com"
+	var Timeout = 60
+	var Timeout2 = 45
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMonitorDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(`
+				resource "uptimerobot_monitor" "test" {
+					friendly_name  = "%s"
+					type           = "%s"
+					url            = "%s"
+					timeout        = "%d"
+				}
+				`, FriendlyName, Type, URL, Timeout),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "friendly_name", FriendlyName),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "type", Type),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "url", URL),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "timeout", fmt.Sprintf(`%d`, Timeout)),
+				),
+			},
+			resource.TestStep{
+				ResourceName: "uptimerobot_monitor.test",
+				ImportState:  true,
+				// NB: Disabled due to http_method issue
+				// ImportStateVerify: true,
+			},
+			resource.TestStep{
+				Config: fmt.Sprintf(`
+				resource "uptimerobot_monitor" "test" {
+					friendly_name  = "%s"
+					type           = "%s"
+					url            = "%s"
+					timeout        = "%d"
+				}
+				`, FriendlyName, Type, URL, Timeout2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "friendly_name", FriendlyName),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "type", Type),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "url", URL),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "timeout", fmt.Sprintf(`%d`, Timeout2)),
+				),
+			},
+			resource.TestStep{
+				ResourceName: "uptimerobot_monitor.test",
+				ImportState:  true,
+				// NB: Disabled due to http_method issue
+				// ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestUptimeRobotDataResourceMonitor_custom_timeout_port(t *testing.T) {
+	var FriendlyName = "TF Test: custom timeout port"
+	var Type = "port"
+	var URL = "google.com"
+	var SubType = "http"
+	var Timeout = 60
+	var Timeout2 = 45
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMonitorDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(`
+				resource "uptimerobot_monitor" "test" {
+					friendly_name = "%s"
+					type          = "%s"
+					url           = "%s"
+					sub_type      = "%s"
+					timeout       = "%d"
+				}
+				`, FriendlyName, Type, URL, SubType, Timeout),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "friendly_name", FriendlyName),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "type", Type),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "url", URL),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "sub_type", SubType),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "timeout", fmt.Sprintf(`%d`, Timeout)),
+				),
+			},
+			resource.TestStep{
+				ResourceName: "uptimerobot_monitor.test",
+				ImportState:  true,
+				// NB: Disabled due to http_method issue
+				// ImportStateVerify: true,
+			},
+			resource.TestStep{
+				Config: fmt.Sprintf(`
+				resource "uptimerobot_monitor" "test" {
+					friendly_name = "%s"
+					type          = "%s"
+					url           = "%s"
+					sub_type      = "%s"
+					timeout       = "%d"
+				}
+				`, FriendlyName, Type, URL, SubType, Timeout2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "friendly_name", FriendlyName),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "type", Type),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "url", URL),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "sub_type", SubType),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "timeout", fmt.Sprintf(`%d`, Timeout2)),
+				),
+			},
+			resource.TestStep{
+				ResourceName: "uptimerobot_monitor.test",
+				ImportState:  true,
+				// NB: Disabled due to http_method issue
+				// ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestUptimeRobotDataResourceMonitor_custom_timeout_keyword(t *testing.T) {
+	var FriendlyName = "TF Test: custom timeout keyword"
+	var Type = "keyword"
+	var URL = "https://google.com"
+	var KeywordType = "not exists"
+	var KeywordValue = "yahoo"
+	var Timeout = 60
+	var Timeout2 = 45
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMonitorDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(`
+				resource "uptimerobot_monitor" "test" {
+					friendly_name = "%s"
+					type          = "%s"
+					url           = "%s"
+					keyword_type  = "%s"
+					keyword_value = "%s"
+					timeout       = "%d"
+				}
+				`, FriendlyName, Type, URL, KeywordType, KeywordValue, Timeout),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "friendly_name", FriendlyName),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "type", Type),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "url", URL),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "keyword_type", KeywordType),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "keyword_value", KeywordValue),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "timeout", fmt.Sprintf(`%d`, Timeout)),
+				),
+			},
+			resource.TestStep{
+				ResourceName: "uptimerobot_monitor.test",
+				ImportState:  true,
+				// NB: Disabled due to http_method issue
+				// ImportStateVerify: true,
+			},
+			resource.TestStep{
+				Config: fmt.Sprintf(`
+				resource "uptimerobot_monitor" "test" {
+					friendly_name = "%s"
+					type          = "%s"
+					url           = "%s"
+					keyword_type  = "%s"
+					keyword_value = "%s"
+					timeout       = "%d"
+				}
+				`, FriendlyName, Type, URL, KeywordType, KeywordValue, Timeout2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "friendly_name", FriendlyName),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "type", Type),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "url", URL),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "keyword_type", KeywordType),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "keyword_value", KeywordValue),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "timeout", fmt.Sprintf(`%d`, Timeout2)),
+				),
+			},
+			resource.TestStep{
+				ResourceName: "uptimerobot_monitor.test",
+				ImportState:  true,
+				// NB: Disabled due to http_method issue
+				// ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestUptimeRobotDataResourceMonitor_http_method(t *testing.T) {
 	var FriendlyName = "TF Test: http method monitor"
 	var Type = "http"


### PR DESCRIPTION
Added `timeout` parameter to the provider.

Test results in local environment.

```
$ TF_ACC=1 go test -v ./... -run TestUptimeRobotDataResourceMonitor_custom_timeout_
?       github.com/vexxhost/terraform-provider-uptimerobot      [no test files]
=== RUN   TestUptimeRobotDataResourceMonitor_custom_timeout_http
2022/09/06 11:47:48 [DEBUG] POST https://api.uptimerobot.com/v2/newMonitor
2022/09/06 11:47:50 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 11:47:53 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 11:47:55 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 11:47:57 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 11:47:59 [DEBUG] POST https://api.uptimerobot.com/v2/editMonitor
2022/09/06 11:48:01 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 11:48:03 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 11:48:04 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 1s (10 left)
2022/09/06 11:48:09 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 11:48:11 [DEBUG] POST https://api.uptimerobot.com/v2/deleteMonitor
2022/09/06 11:48:11 [DEBUG] POST https://api.uptimerobot.com/v2/deleteMonitor (status: 429): retrying in 39s (10 left)
2022/09/06 11:48:50 [DEBUG] POST https://api.uptimerobot.com/v2/deleteMonitor (status: 429): retrying in 2s (9 left)
2022/09/06 11:48:53 [DEBUG] POST https://api.uptimerobot.com/v2/deleteMonitor (status: 429): retrying in 3s (8 left)
2022/09/06 11:48:56 [DEBUG] POST https://api.uptimerobot.com/v2/deleteMonitor (status: 429): retrying in 1s (7 left)
2022/09/06 11:48:57 [DEBUG] POST https://api.uptimerobot.com/v2/deleteMonitor (status: 429): retrying in 2s (6 left)
2022/09/06 11:48:59 [DEBUG] POST https://api.uptimerobot.com/v2/deleteMonitor (status: 429): retrying in 2s (5 left)
2022/09/06 11:49:03 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 11:49:03 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 2s (10 left)
2022/09/06 11:49:06 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 3s (9 left)
2022/09/06 11:49:09 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 1s (8 left)
2022/09/06 11:49:10 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 39s (7 left)
2022/09/06 11:49:50 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 2s (6 left)
2022/09/06 11:49:52 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 3s (5 left)
2022/09/06 11:49:55 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 1s (4 left)
2022/09/06 11:49:56 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 2s (3 left)
2022/09/06 11:49:59 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 2s (2 left)
2022/09/06 11:50:01 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 1s (1 left)
--- PASS: TestUptimeRobotDataResourceMonitor_custom_timeout_http (136.99s)
=== RUN   TestUptimeRobotDataResourceMonitor_custom_timeout_port
2022/09/06 11:50:05 [DEBUG] POST https://api.uptimerobot.com/v2/newMonitor
2022/09/06 11:50:06 [DEBUG] POST https://api.uptimerobot.com/v2/newMonitor (status: 429): retrying in 2s (10 left)
2022/09/06 11:50:09 [DEBUG] POST https://api.uptimerobot.com/v2/newMonitor (status: 429): retrying in 0s (9 left)
2022/09/06 11:50:10 [DEBUG] POST https://api.uptimerobot.com/v2/newMonitor (status: 429): retrying in 38s (8 left)
2022/09/06 11:50:49 [DEBUG] POST https://api.uptimerobot.com/v2/newMonitor (status: 429): retrying in 2s (7 left)
2022/09/06 11:50:53 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 11:50:54 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 1s (10 left)
2022/09/06 11:50:58 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 11:51:01 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 11:51:03 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 11:51:05 [DEBUG] POST https://api.uptimerobot.com/v2/editMonitor
2022/09/06 11:51:07 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 11:51:08 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 1s (10 left)
2022/09/06 11:51:09 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 39s (9 left)
2022/09/06 11:51:50 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 11:51:51 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 2s (10 left)
2022/09/06 11:51:57 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 11:51:59 [DEBUG] POST https://api.uptimerobot.com/v2/deleteMonitor
2022/09/06 11:52:01 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
--- PASS: TestUptimeRobotDataResourceMonitor_custom_timeout_port (120.08s)
=== RUN   TestUptimeRobotDataResourceMonitor_custom_timeout_keyword
2022/09/06 11:52:05 [DEBUG] POST https://api.uptimerobot.com/v2/newMonitor
2022/09/06 11:52:06 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 11:52:08 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 11:52:12 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 11:52:14 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 11:52:15 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 35s (10 left)
2022/09/06 11:52:51 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 2s (9 left)
2022/09/06 11:52:54 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 3s (8 left)
2022/09/06 11:52:59 [DEBUG] POST https://api.uptimerobot.com/v2/editMonitor
2022/09/06 11:53:01 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 11:53:02 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 2s (10 left)
2022/09/06 11:53:04 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 2s (9 left)
2022/09/06 11:53:07 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 2s (8 left)
2022/09/06 11:53:09 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 3s (7 left)
2022/09/06 11:53:12 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 2s (6 left)
2022/09/06 11:53:14 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 36s (5 left)
2022/09/06 11:53:53 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 11:53:56 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 11:53:57 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors (status: 429): retrying in 2s (10 left)
2022/09/06 11:54:01 [DEBUG] POST https://api.uptimerobot.com/v2/deleteMonitor
2022/09/06 11:54:04 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
--- PASS: TestUptimeRobotDataResourceMonitor_custom_timeout_keyword (122.51s)
PASS
ok      github.com/vexxhost/terraform-provider-uptimerobot/internal/provider    379.591s
?       github.com/vexxhost/terraform-provider-uptimerobot/internal/provider/api        [no test files]
```