### PR TITLE
Add custom_http_statuses

### DIFF
--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -54,6 +54,9 @@ resource "uptimerobot_monitor" "my_website" {
   - `basic`
   - `digest`
 * `interval` - the interval for the monitoring check (300 seconds by default).
+* `custom_http_statuses`
+  - `up` - Array of HTTP status codes that make the status of the monitor up
+  - `down` - Array of HTTP status codes that make the status of the monitor down
 
 ## Attributes Reference
 

--- a/internal/provider/api/monitor.go
+++ b/internal/provider/api/monitor.go
@@ -64,6 +64,11 @@ type MonitorAlertContact struct {
 	Threshold  int    `json:"threshold"`
 }
 
+type MonitorRequestCustomHTTPStatuses struct {
+	Up   []int
+	Down []int
+}
+
 type Monitor struct {
 	ID           int    `json:"id"`
 	FriendlyName string `json:"friendly_name"`
@@ -87,6 +92,8 @@ type Monitor struct {
 
 	CustomHTTPHeaders map[string]string
 
+	CustomHTTPStatuses MonitorRequestCustomHTTPStatuses
+
 	AlertContacts []MonitorAlertContact
 }
 
@@ -95,6 +102,7 @@ func (client UptimeRobotApiClient) GetMonitor(id int) (m Monitor, err error) {
 	data.Add("monitors", fmt.Sprintf("%d", id))
 	data.Add("ssl", fmt.Sprintf("%d", 1))
 	data.Add("custom_http_headers", fmt.Sprintf("%d", 1))
+	data.Add("custom_http_statuses", fmt.Sprintf("%d", 1))
 	data.Add("alert_contacts", fmt.Sprintf("%d", 1))
 
 	body, err := client.MakeCall(
@@ -180,6 +188,21 @@ func (client UptimeRobotApiClient) GetMonitor(id int) (m Monitor, err error) {
 	}
 	m.CustomHTTPHeaders = customHTTPHeaders
 
+	if httpStatuses, ok := monitor["custom_http_statuses"].(map[string]interface{}); ok {
+		for _, up := range httpStatuses["up"].([]interface{}) {
+			v := int(up.(float64))
+			if v >= 400 {
+				m.CustomHTTPStatuses.Up = append(m.CustomHTTPStatuses.Up, v)
+			}
+		}
+		for _, down := range httpStatuses["down"].([]interface{}) {
+			v := int(down.(float64))
+			if v < 400 {
+				m.CustomHTTPStatuses.Down = append(m.CustomHTTPStatuses.Down, v)
+			}
+		}
+	}
+
 	if contacts := monitor["alert_contacts"].([]interface{}); contacts != nil {
 		m.AlertContacts = make([]MonitorAlertContact, len(contacts))
 		for k, v := range contacts {
@@ -222,6 +245,8 @@ type MonitorCreateRequest struct {
 	AlertContacts []MonitorRequestAlertContact
 
 	CustomHTTPHeaders map[string]string
+
+	CustomHTTPStatuses MonitorRequestCustomHTTPStatuses
 }
 
 func (client UptimeRobotApiClient) CreateMonitor(req MonitorCreateRequest) (m Monitor, err error) {
@@ -277,6 +302,20 @@ func (client UptimeRobotApiClient) CreateMonitor(req MonitorCreateRequest) (m Mo
 		}
 	}
 
+	// custom http statuses
+	if len(req.CustomHTTPStatuses.Up) != 0 || len(req.CustomHTTPStatuses.Down) != 0 {
+		statusStrings := make([]string, 0)
+		for _, v := range req.CustomHTTPStatuses.Down {
+			s := fmt.Sprintf("%d:0", v)
+			statusStrings = append(statusStrings, s)
+		}
+		for _, v := range req.CustomHTTPStatuses.Up {
+			s := fmt.Sprintf("%d:1", v)
+			statusStrings = append(statusStrings, s)
+		}
+		data.Add("custom_http_statuses", strings.Join(statusStrings, "_"))
+	}
+
 	body, err := client.MakeCall(
 		"newMonitor",
 		data.Encode(),
@@ -314,6 +353,8 @@ type MonitorUpdateRequest struct {
 	AlertContacts []MonitorRequestAlertContact
 
 	CustomHTTPHeaders map[string]string
+
+	CustomHTTPStatuses MonitorRequestCustomHTTPStatuses
 }
 
 func (client UptimeRobotApiClient) UpdateMonitor(req MonitorUpdateRequest) (m Monitor, err error) {
@@ -366,6 +407,22 @@ func (client UptimeRobotApiClient) UpdateMonitor(req MonitorUpdateRequest) (m Mo
 	} else {
 		//delete custom http headers when it is empty
 		data.Add("custom_http_headers", "{}")
+	}
+
+	// custom http statuses
+	if len(req.CustomHTTPStatuses.Up) != 0 || len(req.CustomHTTPStatuses.Down) != 0 {
+		statusStrings := make([]string, 0)
+		for _, v := range req.CustomHTTPStatuses.Down {
+			s := fmt.Sprintf("%d:0", v)
+			statusStrings = append(statusStrings, s)
+		}
+		for _, v := range req.CustomHTTPStatuses.Up {
+			s := fmt.Sprintf("%d:1", v)
+			statusStrings = append(statusStrings, s)
+		}
+		data.Add("custom_http_statuses", strings.Join(statusStrings, "_"))
+	} else {
+		data.Add("custom_http_statuses", "200:1")
 	}
 
 	_, err = client.MakeCall(

--- a/internal/provider/resource_uptimerobot_monitor.go
+++ b/internal/provider/resource_uptimerobot_monitor.go
@@ -115,6 +115,28 @@ func resourceMonitor() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 			},
+			"custom_http_statuses": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"up": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeInt,
+							},
+						},
+						"down": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeInt,
+							},
+						},
+					},
+				},
+			},
 			// TODO - mwindows
 		},
 	}
@@ -170,6 +192,17 @@ func resourceMonitorCreate(d *schema.ResourceData, m interface{}) error {
 	req.CustomHTTPHeaders = make(map[string]string, len(httpHeaderMap))
 	for k, v := range httpHeaderMap {
 		req.CustomHTTPHeaders[k] = v.(string)
+	}
+
+	// custom_http_statuses
+	for _, httpStatuses := range d.Get("custom_http_statuses").(*schema.Set).List() {
+		httpStatusesMap := httpStatuses.(map[string]interface{})
+		for _, up := range httpStatusesMap["up"].([]interface{}) {
+			req.CustomHTTPStatuses.Up = append(req.CustomHTTPStatuses.Up, up.(int))
+		}
+		for _, down := range httpStatusesMap["down"].([]interface{}) {
+			req.CustomHTTPStatuses.Down = append(req.CustomHTTPStatuses.Down, down.(int))
+		}
 	}
 
 	monitor, err := m.(uptimerobotapi.UptimeRobotApiClient).CreateMonitor(req)
@@ -254,6 +287,17 @@ func resourceMonitorUpdate(d *schema.ResourceData, m interface{}) error {
 		req.CustomHTTPHeaders[k] = v.(string)
 	}
 
+	// custom_http_statuses
+	for _, httpStatuses := range d.Get("custom_http_statuses").(*schema.Set).List() {
+		httpStatusesMap := httpStatuses.(map[string]interface{})
+		for _, up := range httpStatusesMap["up"].([]interface{}) {
+			req.CustomHTTPStatuses.Up = append(req.CustomHTTPStatuses.Up, up.(int))
+		}
+		for _, down := range httpStatusesMap["down"].([]interface{}) {
+			req.CustomHTTPStatuses.Down = append(req.CustomHTTPStatuses.Down, down.(int))
+		}
+	}
+
 	monitor, err := m.(uptimerobotapi.UptimeRobotApiClient).UpdateMonitor(req)
 	if err != nil {
 		return err
@@ -301,6 +345,17 @@ func updateMonitorResource(d *schema.ResourceData, m uptimerobotapi.Monitor) err
 
 	if err := d.Set("custom_http_headers", m.CustomHTTPHeaders); err != nil {
 		return fmt.Errorf("error setting custom_http_headers for resource %s: %s", d.Id(), err)
+	}
+
+	if len(m.CustomHTTPStatuses.Up) > 0 || len(m.CustomHTTPStatuses.Down) > 0 {
+		rawHTTPStatuses := make([]map[string]interface{}, 1)
+		rawHTTPStatuses[0] = map[string]interface{}{
+			"up":   m.CustomHTTPStatuses.Up,
+			"down": m.CustomHTTPStatuses.Down,
+		}
+		if err := d.Set("custom_http_statuses", rawHTTPStatuses); err != nil {
+			return fmt.Errorf("error setting custom_http_statuses for resource %s: %s", d.Id(), err)
+		}
 	}
 
 	rawContacts := make([]map[string]interface{}, len(m.AlertContacts))

--- a/internal/provider/resource_uptimerobot_monitor_test.go
+++ b/internal/provider/resource_uptimerobot_monitor_test.go
@@ -412,6 +412,48 @@ func TestUptimeRobotDataResourceMonitor_custom_http_headers(t *testing.T) {
 	})
 }
 
+func TestUptimeRobotDataResourceMonitor_custom_http_statuses(t *testing.T) {
+	var FriendlyName = "TF Test: custom http statuses"
+	var Type = "http"
+	var URL = "https://google.com"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMonitorDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(`
+				resource "uptimerobot_monitor" "test" {
+					friendly_name = "%s"
+					type          = "%s"
+					url           = "%s"
+					custom_http_statuses {
+						up = [404]
+						down = [200, 302]
+					}
+				}
+				`, FriendlyName, Type, URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "friendly_name", FriendlyName),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "type", Type),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "url", URL),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "custom_http_statuses.0.up.#", "1"),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "custom_http_statuses.0.up.0", "404"),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "custom_http_statuses.0.down.#", "2"),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "custom_http_statuses.0.down.0", "200"),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "custom_http_statuses.0.down.1", "302"),
+				),
+			},
+			resource.TestStep{
+				ResourceName: "uptimerobot_monitor.test",
+				ImportState:  true,
+				// NB: Disabled due to http_method issue
+				// ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestUptimeRobotDataResourceMonitor_ping_monitor(t *testing.T) {
 	var FriendlyName = "TF Test: ping monitor"
 	var Type = "ping"


### PR DESCRIPTION
ref: https://github.com/louy/terraform-provider-uptimerobot/pull/89

Added test to PR submitted to `louy/terraform-provider-uptimerobot`.
It is a very good fix and I hope it will be merged.

In my local:

```
$ TF_ACC=1 go test -v ./... -run TestUptimeRobotDataResourceMonitor_custom_http_statuses
?       github.com/vexxhost/terraform-provider-uptimerobot      [no test files]
=== RUN   TestUptimeRobotDataResourceMonitor_custom_http_statuses
2022/09/06 20:39:55 [DEBUG] POST https://api.uptimerobot.com/v2/newMonitor
2022/09/06 20:39:58 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 20:40:00 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 20:40:04 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
2022/09/06 20:40:06 [DEBUG] POST https://api.uptimerobot.com/v2/deleteMonitor
2022/09/06 20:40:07 [DEBUG] POST https://api.uptimerobot.com/v2/getMonitors
--- PASS: TestUptimeRobotDataResourceMonitor_custom_http_statuses (15.61s)
PASS
ok      github.com/vexxhost/terraform-provider-uptimerobot/internal/provider    15.622s
?       github.com/vexxhost/terraform-provider-uptimerobot/internal/provider/api        [no test files]
```