### PR TITLE
reenabled windows build target

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,7 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
     goarch:
       - amd64
       - arm64


### PR DESCRIPTION
our team works in a multiplatform environment, where it is really cumbersome not to have native windows builds. in the sense of go and software/platform-diversity please reenable the windows builds. it would really help.

it would feel really odd to maintain a fork of this provider just with the difference having a windows build.